### PR TITLE
xsd: expose xsd:documentation definitions to templates for godoc comments

### DIFF
--- a/pkg/xsd/documentation.go
+++ b/pkg/xsd/documentation.go
@@ -1,0 +1,20 @@
+package xsd
+
+import "strings"
+
+// Documentation is a single xsd:documentation node within an xsd:annotation.
+type Documentation struct {
+	Source string `xml:"source,attr"`
+	Value  string `xml:",chardata"`
+}
+
+// definition returns the ISO 20022 "Definition" documentation from docs,
+// whitespace-normalised to a single line; it returns "" when none is present.
+func definition(docs []Documentation) string {
+	for _, doc := range docs {
+		if strings.EqualFold(doc.Source, "Definition") {
+			return strings.Join(strings.Fields(doc.Value), " ")
+		}
+	}
+	return ""
+}

--- a/pkg/xsd/element.go
+++ b/pkg/xsd/element.go
@@ -23,8 +23,18 @@ type Element struct {
 	ComplexType     *ComplexType `xml:"complexType"`
 	SimpleType      *SimpleType  `xml:"simpleType"`
 	schema          *Schema      `xml:"-"`
-	typ             Type         `xml:"-"`
-	Doc             []string     `xml:"annotation>documentation"`
+	typ             Type            `xml:"-"`
+	Doc             []Documentation `xml:"annotation>documentation"`
+}
+
+func (e *Element) Definition() string {
+	if def := definition(e.Doc); def != "" {
+		return def
+	}
+	if e.refElm != nil {
+		return definition(e.refElm.Doc)
+	}
+	return ""
 }
 
 func (e *Element) Attributes() []Attribute {

--- a/pkg/xsd/types.go
+++ b/pkg/xsd/types.go
@@ -53,6 +53,11 @@ type ComplexType struct {
 	ComplexContent   *ComplexContent `xml:"complexContent"`
 	Choice           *Choice         `xml:"choice"`
 	content          GenericContent  `xml:"-"`
+	Doc              []Documentation `xml:"annotation>documentation"`
+}
+
+func (ct *ComplexType) Definition() string {
+	return definition(ct.Doc)
 }
 
 func (ct *ComplexType) Attributes() []Attribute {
@@ -164,10 +169,15 @@ func (ct *ComplexType) compile(sch *Schema, parentElement *Element) {
 }
 
 type SimpleType struct {
-	XMLName     xml.Name     `xml:"http://www.w3.org/2001/XMLSchema simpleType"`
-	Name        string       `xml:"name,attr"`
-	Restriction *Restriction `xml:"restriction"`
-	schema      *Schema      `xml:"-"`
+	XMLName     xml.Name        `xml:"http://www.w3.org/2001/XMLSchema simpleType"`
+	Name        string          `xml:"name,attr"`
+	Restriction *Restriction    `xml:"restriction"`
+	schema      *Schema         `xml:"-"`
+	Doc         []Documentation `xml:"annotation>documentation"`
+}
+
+func (st *SimpleType) Definition() string {
+	return definition(st.Doc)
 }
 
 func (st *SimpleType) GoName() string {


### PR DESCRIPTION
## What

Adds a `Documentation` type and `Definition()` accessors so templates can emit ISO 20022 definitions as Go doc comments.

- `pkg/xsd/documentation.go`: new `Documentation{Source, Value}` plus a `definition()` helper that returns the `source="Definition"` text, whitespace-normalised to a single line (empty when absent).
- `pkg/xsd/element.go`: `Element.Doc` changed from `[]string` to `[]Documentation`; adds `Element.Definition()` (falls back to a referenced element's docs).
- `pkg/xsd/types.go`: `ComplexType` and `SimpleType` gain `Doc []Documentation` and `Definition()`.

## Why

The Fedwire 2026 "enriched" ISO 20022 schemas carry `<xs:documentation source="Name|Definition">` on every type and element. Previously the parser captured only a flat `[]string` on `Element` (both Name and Definition, no way to tell them apart) and nothing on types. Exposing the definition lets downstream templates generate godoc-style comments above each type and struct field.

## Compatibility

`Element.Doc` type changed (`[]string` → `[]Documentation`); the only consumer is templates, which now use `.Definition`. No behavior change for callers that don't reference docs.